### PR TITLE
Allow multiple dates in `cvEntry`

### DIFF
--- a/cv.typ
+++ b/cv.typ
@@ -261,8 +261,8 @@
 /// Add an entry to the CV.
 ///
 /// - title (str): The title of the entry.
-/// - society (str): The society of the entr (company, university, etc.).
-/// - date (str): The date of the entry.
+/// - society (str): The society of the entry (company, university, etc.).
+/// - date (str | content): The date(s) of the entry.
 /// - location (str): The location of the entry.
 /// - description (array): The description of the entry. It can be a string or an array of strings.
 /// - logo (image): The logo of the society. If empty, no logo will be displayed.
@@ -306,6 +306,12 @@
       right,
       text(size: 8pt, weight: "medium", fill: gray, style: "oblique", str),
     )
+  }
+  let entryDatesStyle(dates) = {
+    [
+      #set list(marker: [])
+      #dates
+    ]
   }
   let entryDescriptionStyle(str) = {
     text(
@@ -366,59 +372,78 @@
 
   v(beforeEntrySkip)
   table(
-    columns: (ifLogo(logo, 4%, 0%), 1fr),
+    columns: (1fr, auto),
     inset: 0pt,
     stroke: none,
-    align: horizon,
-    column-gutter: ifLogo(logo, 4pt, 0pt),
-    setLogoContent(logo),
-    table(
-      columns: (1fr, auto),
-      inset: 0pt,
-      stroke: none,
-      row-gutter: 6pt,
-      align: auto,
-      {
-        entryA1Style(
-          ifSocietyFirst(
-            metadata.layout.entry.display_entry_society_first,
-            society,
-            title,
-          ),
-        )
-      },
-      {
-        entryA2Style(
-          ifSocietyFirst(
-            metadata.layout.entry.display_entry_society_first,
-            location,
-            date,
-          ),
-        )
-      },
+    gutter: 6pt,
+    align: auto,
+    {
+      table(
+        columns: (ifLogo(logo, 4%, 0%), 1fr),
+        inset: 0pt,
+        stroke: none,
+        align: horizon,
+        column-gutter: ifLogo(logo, 4pt, 0pt),
+        setLogoContent(logo),
+        table(
+          columns: auto,
+          inset: 0pt,
+          stroke: none,
+          row-gutter: 6pt,
+          align: auto,
+          {
+            entryA1Style(
+              ifSocietyFirst(
+                metadata.layout.entry.display_entry_society_first,
+                society,
+                title,
+              ),
+            )
+          },
 
-      {
-        entryB1Style(
-          ifSocietyFirst(
-            metadata.layout.entry.display_entry_society_first,
-            title,
-            society,
-          ),
-        )
-      },
-      {
-        entryB2Style(
-          ifSocietyFirst(
-            metadata.layout.entry.display_entry_society_first,
-            date,
-            location,
-          ),
-        )
-      },
-    ),
+          {
+            entryB1Style(
+              ifSocietyFirst(
+                metadata.layout.entry.display_entry_society_first,
+                title,
+                society,
+              ),
+            )
+          },
+        ),
+      )
+      entryDescriptionStyle(description)
+      entryTagListStyle(tags)
+    },
+    {
+      table(
+        columns: auto,
+        inset: 0pt,
+        stroke: none,
+        row-gutter: 6pt,
+        align: auto,
+        {
+          entryA2Style(
+            ifSocietyFirst(
+              metadata.layout.entry.display_entry_society_first,
+              location,
+              entryDatesStyle(date),
+            ),
+          )
+        },
+
+        {
+          entryB2Style(
+            ifSocietyFirst(
+              metadata.layout.entry.display_entry_society_first,
+              entryDatesStyle(date),
+              location,
+            ),
+          )
+        }
+      )
+    },
   )
-  entryDescriptionStyle(description)
-  entryTagListStyle(tags)
 }
 
 /// Add a skill to the CV.

--- a/template/modules_en/professional.typ
+++ b/template/modules_en/professional.typ
@@ -36,7 +36,10 @@
   title: [Data Analysis Intern],
   society: [PQR Corporation],
   logo: image("../src/logos/pqr_corp.png"),
-  date: [Summer 2017],
+  date: list(
+    [Summer 2017],
+    [Summer 2016],
+  ),
   location: [Chicago, IL],
   description: list([Assisted with data cleaning, processing, and analysis using Python and Excel, participated in team meetings and contributed to project planning and execution]),
 )

--- a/template/modules_fr/professional.typ
+++ b/template/modules_fr/professional.typ
@@ -35,7 +35,10 @@
 #cvEntry(
   title: [Stagiaire en Analyse de Données],
   society: [PQR Corporation],
-  date: [été 2017],
+  date: list(
+    [été 2017],
+    [été 2016],
+  ),
   location: [Chicago, IL],
   logo: image("../src/logos/pqr_corp.png"),
   description: list([Aider à la préparation, au traitement et à l'analyse de données à l'aide de Python et Excel, participer aux réunions d'équipe et contribuer à la planification et à l'exécution de projets]),

--- a/template/modules_zh/professional.typ
+++ b/template/modules_zh/professional.typ
@@ -36,7 +36,10 @@
   title: [数据分析实习生],
   society: [PQR 公司],
   logo: image("../src/logos/pqr_corp.png"),
-  date: [2017年夏季],
+  date: list(
+    [2017年夏季],
+    [2016年夏季],
+  ),
   location: [芝加哥, IL],
   description: list([协助使用 Python 和 Excel 进行数据清洗、处理和分析，参与团队会议并为项目规划和执行做出贡献]),
 )


### PR DESCRIPTION
This pull request introduces support for multiple dates for a single position. The feature reduces redundancy and saves space for recurring roles such as internships and teaching assistant positions.
To achieve this, a `cvEntry` is split into two columns: the first column contains the `logo`, `title`, `society`, `description`, and `tags`, while the second column displays the `location` and `date`(s) only.

![image](https://github.com/user-attachments/assets/302b5ad8-d7ec-4875-98b0-1d7dccc92b39)
