### PR TITLE
Add `cvSkillTag`

### DIFF
--- a/cv.typ
+++ b/cv.typ
@@ -444,6 +444,20 @@
   v(-6pt)
 }
 
+/// Add a skill tag to the CV.
+/// 
+/// - skill (str | content): The skill to be displayed.
+/// -> content
+#let cvSkillTag(skill) = {
+  box(
+    inset: (x: 0.5em, y: 0.5em),
+    stroke: 0.5pt + regularColors.lightgray,
+    radius: 3pt,
+    text(size: 10pt, weight: "regular", skill),
+  )
+  h(5pt)
+}
+
 /// Add a Honor to the CV.
 ///
 /// - date (str): The date of the honor.


### PR DESCRIPTION
This pull request adds `cvSkillTag`s. Sometimes it’s difficult to assign a specific type to individual skills, so I wanted a way to present them without categorization, while keeping the layout visually appealing.

![image](https://github.com/user-attachments/assets/d14a4ec6-0af5-42b3-b7f0-38c071bb65bf)
