### PR TITLE
Improve metadata schema

### DIFF
--- a/metadata.toml.schema.json
+++ b/metadata.toml.schema.json
@@ -19,27 +19,27 @@
         "before_section_skip": {
           "type": "string",
           "description": "Spacing before sections",
-          "pattern": "^[0-9]+pt$"
+          "pattern": "^\\d*\\.?\\d+([eE][+-]?\\d+)?(pt|mm|cm|in|em)$"
         },
         "before_entry_skip": {
           "type": "string",
           "description": "Spacing before entries",
-          "pattern": "^[0-9]+pt$"
+          "pattern": "^\\d*\\.?\\d+([eE][+-]?\\d+)?(pt|mm|cm|in|em)$"
         },
         "before_entry_description_skip": {
           "type": "string",
           "description": "Spacing before entry descriptions",
-          "pattern": "^[0-9]+pt$"
+          "pattern": "^\\d*\\.?\\d+([eE][+-]?\\d+)?(pt|mm|cm|in|em)$"
         },
         "paper_size" : {
           "type": "string",
-          "description": "Sets paper size and standard marigins, Optional values: us-letter. Default is a4.",
+          "description": "Sets paper size and standard margins, Optional values: us-letter. Default is a4.",
           "pattern": "^(a4|us-letter|#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3}))$"
         },
         "date_width": {
           "type": "string",
           "description": "Width of the right column of a cvEntry",
-          "pattern": "^\\d+(\\.\\d+)?(pt|mm|cm|in|em)$"
+          "pattern": "^\\d*\\.?\\d+([eE][+-]?\\d+)?(pt|mm|cm|in|em)$"
         },
         "fonts": {
           "type": "object",
@@ -70,7 +70,7 @@
             "info_font_size": {
               "type": "string",
               "description": "Font size for personal info",
-              "pattern": "^[0-9]+pt$"
+              "pattern": "^\\d*\\.?\\d+([eE][+-]?\\d+)?(pt|mm|cm|in|em)$"
             }
           },
           "required": ["header_align", "display_profile_photo"]

--- a/template/metadata.toml
+++ b/template/metadata.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/mintyfrankie/brilliant-CV/main/metadata.toml.schema.json
+#:schema https://raw.githubusercontent.com/yunanwg/brilliant-CV/main/metadata.toml.schema.json
 
 # Set the output language
 # INFO: value must matches folder suffix; i.e "zh" -> "./modules_zh"


### PR DESCRIPTION
This pull request updates the pattern for properties that should hold a length in the `metadata.toml.schema.json` to align with [Typst's length definition](https://typst.app/docs/reference/layout/length/). This allows for more complex , such as `.05e2cm`.
Additionally, it updates the schema URL in `metadata.toml` (I assume you changed your GitHub username at some point?).