### PR TITLE
Replace _mintyfrankie_ by _yunanwg_ where needed

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*      @mintyfrankie
+*      @yunanwg

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: mintyfrankie
+github: yunanwg

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <br>
 
-> If my work helps you drift through tedious job seeking journey, don't hesitate to think about [buying me a Coke Zero](https://github.com/sponsors/mintyfrankie)... or a lot of them! 🥤
+> If my work helps you drift through tedious job seeking journey, don't hesitate to think about [buying me a Coke Zero](https://github.com/sponsors/yunanwg)... or a lot of them! 🥤
 
 
 

--- a/docs/docs.typ
+++ b/docs/docs.typ
@@ -9,7 +9,7 @@
 #show: template.with(
   title: "brilliant-cv",
   subtitle: "Documentation",
-  authors: ("mintyfrankie"),
+  authors: ("yunanwg"),
   version: version,
 )
 
@@ -140,11 +140,11 @@ last_name = "Doe"
 # The order of this section will affect how the entries are displayed
 # The custom value is for any additional information you want to add
 [personal.info]
-github = "mintyfrankie"
+github = "yunanwg"
 phone = "+33 6 12 34 56 78"
 email = "john.doe@me.org"
 linkedin = "johndoe"
-# gitlab = "mintyfrankie"
+# gitlab = "yunanwg"
 # homepage: "jd.me.org"
 # orcid = "0000-0000-0000-0000"
 # researchgate = "John-Doe"

--- a/template/metadata.toml
+++ b/template/metadata.toml
@@ -54,11 +54,11 @@ language = "en"
     # The order of this section will affect how the entries are displayed
     # The custom value is for any additional information you want to add, name it as custom-1, custom-2, etc.
     [personal.info]
-        github = "mintyfrankie"
+        github = "yunanwg"
         phone = "+33 6 12 34 56 78"
         email = "john.doe@me.org"
         linkedin = "johndoe"
-        # gitlab = "mintyfrankie"
+        # gitlab = "yunanwg"
         # homepage = "jd.me.org"
         # orcid = "0000-0000-0000-0000"
         # researchgate = "John-Doe"

--- a/typst.toml
+++ b/typst.toml
@@ -2,10 +2,10 @@
 name = "brilliant-cv"
 version = "2.0.4"
 entrypoint = "lib.typ"
-authors = ["Yunan Wang <https://github.com/mintyfrankie>"]
+authors = ["Yunan Wang <https://github.com/yunanwg>"]
 license = "Apache-2.0"
 description = "💼 another CV template for your job application, yet powered by Typst and more"
-repository = "https://github.com/mintyfrankie/brilliant-CV"
+repository = "https://github.com/yunanwg/brilliant-CV"
 keywords = ["cv", "resume", "cover-letter", "curriculum-vitae", "modular", "multilingual", "ai-injection"]
 categories = ["cv", "languages", "layout"]
 compiler = "0.11.0"


### PR DESCRIPTION
This pull request replaces most occurrences of _mintyfrankie_ with _yunanwg_. I've left the GitHub asset links unchanged, as they would break if updated. 
This PR should fix https://github.com/yunanwg/brilliant-CV/issues/93 once a new version is released.