### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -1,4 +1,6 @@
 name: Compile Test
+permissions:
+  contents: read
 
 on:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/yunanwg/brilliant-CV/security/code-scanning/2](https://github.com/yunanwg/brilliant-CV/security/code-scanning/2)

To fix this problem, you must add a `permissions:` block either at the root of the workflow file (to apply to all jobs) or within the `compile` job definition. Since there is only one job (`compile`) and the safest approach is to apply it at the workflow root so all jobs inherit it, you should add the following block near the top of the file:

```yaml
permissions:
  contents: read
```

This change should be applied after the `name:` and before the `on:` block (typically immediately after line 1 or line 2 of the provided file). No imports or other definitions are needed. If you prefer to apply it only to this job, you could add it at job-level (inside `compile:`), but the root-level is cleaner and futureproof.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
