### PR TITLE
docs: restructure AGENTS.md around commands and release flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,12 +29,12 @@ Run `just link` before any local development. This registers the local package w
 - `template/profile_<name>/metadata.toml` — Each profile is a complete, self-contained CV configuration. v4 has no root `metadata.toml`.
 - `template/profile_<name>/*.typ` — Content modules per profile (education, professional, projects, certificates, publications, skills)
 
-Changes to `src/` affect all downstream users. Never break backward compatibility without a deprecation path.
+Changes to `src/` affect all downstream users. To rename a parameter, keep the old name working through the aliasing approach already used in `src/lib.typ`; to retire a template option, ship a deprecation note in the same PR.
 
 ## Things You Will Get Wrong Without Reading This
 
 ### Schema migration guards panic, they don't silently fall back
-`src/lib.typ:_check-v3-legacy` panics on v3-only fields (`language`, `non_latin_font`, `non_latin_name`, `[lang.*]`). The same applies to v2 inject keys (`inject_ai_prompt`, `inject_keywords`). These are **intentional** — do not "fix" them. The v4 design picks panic-with-migration-message over silent fallback to avoid hiding behavior changes.
+`src/lib.typ:_check-v3-legacy` panics on v3-only fields (`language`, `non_latin_font`, `non_latin_name`, `[lang.*]`). The same applies to v2 inject keys (`inject_ai_prompt`, `inject_keywords`). These panics are **intentional**: the v4 design picks panic-with-migration-message over silent fallback to avoid hiding behavior changes. When one fires, migrate the offending `metadata.toml` to the replacement field the panic message names — leave the guard itself alone.
 
 ### Two documentation pages are generated — edit the source, not the output
 - `docs/web/docs/api-reference.md` ← generated from `src/` doc-comments

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,28 @@ Brilliant CV is a **Typst package** (`@preview/brilliant-cv`) for creating modul
 
 ## Before You Start
 
-Run `just link` before any local development. This registers the local package with Typst's resolver. Without it, all imports fail. Run `just` to see all available commands.
+Run `just link` before any local development. This registers the local package with Typst's resolver. Without it, all imports fail.
+
+## Commands
+
+`just` with no argument lists every recipe. These are the ones you need:
+
+| Command | Use it when | Notes |
+|---|---|---|
+| `just link` | Once, before anything else | Without it every import fails |
+| `just build` | You changed `src/` or `template/` | Compiles both starter entrypoints |
+| `just test-fast` | Inner loop | Native, sub-second. Panics + units only — runs **no** visual regression tests |
+| `just test` | Before committing | Full suite, tytanic visual + panic smoke. Needs a running Docker daemon |
+| `just test-update` | A layout change moved pixels on purpose | Regenerates ref PNGs in Docker; review the new PNGs before committing |
+| `just fmt-check` | Before committing | typstyle gate, same image as CI |
+| `just docs-generate` | You changed doc-comments in `src/` or comments in `template/profile_en/metadata.toml` | Regenerates the two generated pages |
+| `just verify-release` | Preparing a release | Full pre-release contract |
 
 ## Critical Architecture
 
 **`src/` is the published package. `template/` is the user-facing starter project.** They are separate concerns:
 - `src/lib.typ` — Package entry point, exports `cv()` and `letter()`
+- `src/cv.typ`, `src/letter.typ` — Component functions (`cv-entry`, `cv-honor`, `cv-skill*`, `cv-publication`, …)
 - `template/profile_<name>/metadata.toml` — Each profile is a complete, self-contained CV configuration. v4 has no root `metadata.toml`.
 - `template/profile_<name>/*.typ` — Content modules per profile (education, professional, projects, certificates, publications, skills)
 
@@ -20,17 +36,23 @@ Changes to `src/` affect all downstream users. Never break backward compatibilit
 ### Schema migration guards panic, they don't silently fall back
 `src/lib.typ:_check-v3-legacy` panics on v3-only fields (`language`, `non_latin_font`, `non_latin_name`, `[lang.*]`). The same applies to v2 inject keys (`inject_ai_prompt`, `inject_keywords`). These are **intentional** — do not "fix" them. The v4 design picks panic-with-migration-message over silent fallback to avoid hiding behavior changes.
 
-### Some files are auto-generated — do not edit manually
+### Two documentation pages are generated — edit the source, not the output
 - `docs/web/docs/api-reference.md` ← generated from `src/` doc-comments
 - `docs/web/docs/configuration.md` ← generated from `template/profile_en/metadata.toml` comments (profile_en is the canonical reference)
 
-Regenerate with `just docs-generate`. Edit the **source comments**, not the output files.
+Edit those source comments, then run `just docs-generate`. Every other page under `docs/web/docs/` is hand-written.
 
 ### Each profile's metadata.toml is the single source of truth for that profile
 All user configuration flows through `template/profile_<name>/metadata.toml`. v4 has no merging or inheritance — one profile = one complete CV configuration. When adding new config options, update the comments in `template/profile_en/metadata.toml` first (it drives docs generation), then mirror to other profiles as needed.
 
-### Tests live in `tests/` and use tytanic + a panic shell runner
-Visual tests run in Docker (`tests/Dockerfile`) on both maintainer machines and CI — refs are pixel-deterministic, no cross-OS noise to absorb. `just test` for the full suite (Docker). `just test-fast` for native sub-second feedback (panics + units only). `just fmt-check` runs typstyle in the same image. CJK regression tests use Noto Sans CJK SC (Linux baseline) instead of macOS Heiti SC — Heiti SC visual fidelity is verified manually by the maintainer with `just dev`. See `tests/README.md` for the full layout.
+### Typst snippets in `docs/` are compile-tested by hand, not by CI
+`just docs-check` compiles the snippets in the generated `api-reference.md` only. For a snippet you write anywhere else in `docs/`, drop it into a temp `.typ`, set up `cv-metadata.update(minimal-metadata)` from `tests/common.typ`, and run `typst compile --root . <file>` inside the test image. Don't ship code from memory — take every public function name and parameter from the actual signature in `src/`, and match the file you check against the import the snippet uses.
+
+### Visual tests are pixel-deterministic because they run in Docker
+Refs are generated in `tests/Dockerfile` on both maintainer machines and CI, so there is no cross-OS noise to absorb. `just test-fast` skipping the visual suite is the main way a regression slips through locally. CJK regression tests use Noto Sans CJK SC (Linux baseline) instead of macOS Heiti SC — Heiti SC visual fidelity is verified manually by the maintainer with `just dev`. See `tests/README.md` for the full layout.
+
+### Releases are a PR flow, not a local tag push
+From a clean checkout of the latest `origin/main`: `just prepare-release <version>` updates the manifest and current-version examples only, then `just verify-release`. Review and merge that as a normal PR, and only then create the `v<version>` tag on that exact `main` commit. The tag workflow fails closed if the tag, manifest, starter imports, and documentation disagree. Full contract in [`CONTRIBUTING.md` §6](CONTRIBUTING.md).
 
 ## Public API Design
 
@@ -41,43 +63,17 @@ Brilliant CV deliberately balances simplicity against flexibility. Before adding
 - Avoid adding a separate option for every isolated styling preference; each option becomes a compatibility and documentation commitment.
 - When new API is justified, keep the surface minimal, preserve backward compatibility, document it, and add a regression test.
 
-See the “Public API design” section in `CONTRIBUTING.md` for the contributor-facing rationale and decision checklist.
+See [`CONTRIBUTING.md` §4.2](CONTRIBUTING.md) for the contributor-facing rationale and decision checklist.
 
 ## Documentation Style
 
-The hand-written pages under `docs/web/docs/` follow ASD-STE100 Simplified Technical English. Most readers of this project are not native English speakers, and these rules keep the pages short, unambiguous, and easy to translate.
-
-Recommended tool: the `simple-english` skill at <https://github.com/AminBlg/SimpleEnglish>. It carries the 53-rule catalog and a mandatory self-check. Use **pragmatic mode**, which keeps domain vocabulary (Typst, profile, metadata, compile). The skill is not vendored in this repository; install it yourself.
-
-In scope: `index.md`, `getting-started.md`, `troubleshooting.md`, `recipes.md`, `migration.md`, `components.md`.
-
-Out of scope: `api-reference.md` and `configuration.md` are generated. To change their prose, edit the doc-comments in `src/` or the comments in `template/profile_en/metadata.toml`, then run `just docs-generate`.
-
-Never rewrite code blocks, inline code, file paths, commands, config keys, or quoted errors. Reflow the prose around them. `just docs-check` does **not** gate these pages: it compiles the snippets in the generated `api-reference.md` only. Verify by diffing every code block and link target against the previous revision.
-
-### Terminology
-
-One term per concept, across every page. These choices are already applied:
-
-| Concept | Use | Not |
-|---|---|---|
-| Configuration data | `configuration` | `config` |
-| The published library | `package` | `framework` |
-| The starter project a user copies | `template` | — |
-| Filesystem location | `directory` | `folder` |
-| Taking something away | `remove` | `delete` |
-| What Typst puts on the page | `render` | `display` |
-| Making information visible to a reader | `show` | `display` |
-| Confirming a state | `make sure that` | `check`, `verify`, `confirm` |
-
-Write `for example` and `that is` instead of `e.g.` and `i.e.` Name the items instead of writing `etc.`
+The hand-written pages under `docs/web/docs/` follow ASD-STE100 Simplified Technical English, with a fixed terminology table and a rule against rewriting code blocks. Read [`CONTRIBUTING.md` §4.4](CONTRIBUTING.md) before you write prose there — the terminology choices are already applied across the site, and CI does not gate them.
 
 ## Conventions
 
 - Conventional commits (`feat:`, `fix:`, `docs:`, etc.)
 - Run `just build && just test` before committing
-- Don't commit PDFs (handled by .gitignore and pre-commit hooks)
+- Don't commit PDFs (handled by `.gitignore` and pre-commit hooks)
 - Tytanic ref PNGs live next to each `test.typ`; commit intentional regenerations alongside the layout change that caused them
 - When fixing a reported issue, add a regression test (tytanic ref or panic shell) that reproduces the reported scenario in the same PR. Skip only when the change is docs-only or policy-only.
-- When writing Typst snippets in `docs/`, compile-test them against `/src` before committing. Drop the snippet into a temp `.typ`, set up `cv-metadata.update(minimal-metadata)` from `/tests/common.typ`, and run `typst compile --root . <file>` inside the test image. Don't ship code from memory — every public function name and parameter has to come from the actual signature in `src/`. `cv()` and `letter()` live in `src/lib.typ`; the component functions (`cv-entry`, `cv-honor`, `cv-skill*`, `cv-publication`, …) live in `src/cv.typ`. Match the file you check against the import the snippet uses.
 - Read `CONTRIBUTING.md` for the full contribution workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ If existing composition is clear enough, prefer documenting that approach. If a 
 2. **Document anything user-facing**:
    - Update `README.md` (or `docs/`) for new parameters.
    - Add comments to `metadata.toml` if you introduce new knobs.
-   - The hand-written pages under `docs/web/docs/` follow Simplified Technical English, with a fixed terminology table. Read the “Documentation Style” section in `AGENTS.md` before you write prose there.
+   - The hand-written pages under `docs/web/docs/` follow Simplified Technical English, with a fixed terminology table. Read [4.4 Documentation style](#44-documentation-style) before you write prose there.
 3. **Keep compatibility**:
    - For renamed parameters, follow the aliasing approach already used in `src/lib.typ`.
    - Don’t remove template options without deprecation notes.
@@ -119,6 +119,35 @@ If existing composition is clear enough, prefer documenting that approach. If a 
 
 5. **Commit using conventional commits** (the repo follows conventional commit messages for history clarity).
 6. **Open a PR** describing the change, how to test it, and screenshots/PDF snippets if the visual output changed.
+
+### 4.4 Documentation style
+
+The hand-written pages under `docs/web/docs/` follow ASD-STE100 Simplified Technical English. Most readers of this project are not native English speakers, and these rules keep the pages short, unambiguous, and easy to translate.
+
+Recommended tool: the `simple-english` skill at <https://github.com/AminBlg/SimpleEnglish>. It carries the 53-rule catalog and a mandatory self-check. Use **pragmatic mode**, which keeps domain vocabulary (Typst, profile, metadata, compile). The skill is not vendored in this repository; install it yourself.
+
+In scope: `index.md`, `getting-started.md`, `troubleshooting.md`, `recipes.md`, `migration.md`, `components.md`.
+
+Out of scope: `api-reference.md` and `configuration.md` are generated. To change their prose, edit the doc-comments in `src/` or the comments in `template/profile_en/metadata.toml`, then run `just docs-generate`.
+
+Never rewrite code blocks, inline code, file paths, commands, config keys, or quoted errors. Reflow the prose around them. `just docs-check` does **not** gate these pages: it compiles the snippets in the generated `api-reference.md` only. Verify by diffing every code block and link target against the previous revision.
+
+#### Terminology
+
+One term per concept, across every page. These choices are already applied:
+
+| Concept | Use | Not |
+|---|---|---|
+| Configuration data | `configuration` | `config` |
+| The published library | `package` | `framework` |
+| The starter project a user copies | `template` | — |
+| Filesystem location | `directory` | `folder` |
+| Taking something away | `remove` | `delete` |
+| What Typst puts on the page | `render` | `display` |
+| Making information visible to a reader | `show` | `display` |
+| Confirming a state | `make sure that` | `check`, `verify`, `confirm` |
+
+Write `for example` and `that is` instead of `e.g.` and `i.e.` Name the items instead of writing `etc.`
 
 ---
 


### PR DESCRIPTION
Restructures `AGENTS.md` against current AGENTS.md practice. Constraint was **restructure, don't reword** — the verified facts stay verbatim; the changes are structural.

- **Commands table** — the recipes an agent needs, previously scattered through prose. Makes two easy-to-miss facts visible: `test-fast` runs no visual tests, `test-update` needs a visual review before committing.
- **Release flow** — it's a PR flow, not a local tag push. Lived only in `CONTRIBUTING.md` §6.
- **Simplified English rulebook → `CONTRIBUTING.md` §4.4**, pointer left behind. Mirrors how Public API design already splits summary from deep dive; terminology table moves verbatim.
- **Deduped** the generated-file and docs-snippet rules (each appeared twice).
- **Paired every bare prohibition with a concrete alternative** — backward compat now names the aliasing approach in `src/lib.typ`; the v3/v2 guards say to migrate the field the panic names.

`.github/copilot-instructions.md` is a symlink to `AGENTS.md` and `CLAUDE.md` is `@AGENTS.md` — both untouched. Every path, recipe, and cross-reference checked against the tree; `just docs-check` clean. Docs-only, so no regression test per repo convention.